### PR TITLE
correct rules nesting in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Defining separately:
   border: solid 1px grey;
   transition: border 1s ease;
 
-  .c-example__heading {
+  &__heading {
   	text-transform: uppercase;
   }
 


### PR DESCRIPTION
It is necessary to avoid such nesting, otherwise the result css-code will be:
```css
.c-example .c-example__heading {
  /* ... */
}
```